### PR TITLE
Replace ◒ with 🎹 as z80 monochrome icon, the ◒  one can be very hard to read sometime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A collection of awesome calculator documentation resources and tools from all over the web, all in one place. Contributions welcome.
 | **Icon** | **Models** |
 | -- | -- |
-| ◒ | <details><summary>Monochrome z80</summary> <ul><li>TI-82</li><li>TI-83</li><li>TI-83+</li><li>TI-84+</li></ul></details> |
+| 🎹 | <details><summary>Monochrome z80</summary> <ul><li>TI-82</li><li>TI-83</li><li>TI-83+</li><li>TI-84+</li></ul></details> |
 | 🎨 | TI-84+CSE |
 | 🌈 | <details><summary>Color ez80</summary> <ul><li>TI-84+CE (-T)</li><li>TI-83 PCE</li><li>Python variants of the above.</li><li>TI-82 AEP</li></ul></details> |
 | 🎈 | TI-Nspire |
@@ -47,39 +47,39 @@ A collection of awesome calculator documentation resources and tools from all ov
 
 - [arTIfiCE](https://yvantt.github.io/arTIfiCE/) - 🌈  
   If you have a newer 84+CE/83PCE (at least OS 5.5), arTIfiCE can be used to unlock the ability to run ASM programs.
-- [TILP](https://github.com/debrouxl/tilp_and_gfm/) - ◒ 🎨 🌈 🎈  
+- [TILP](https://github.com/debrouxl/tilp_and_gfm/) - 🎹 🎨 🌈 🎈  
   TILP can be used as an alternative to TI's official software for sending/receiving files to/from most calculators.
 - [N-Link](https://lights0123.com/n-link/) - 🎈  
   N-Link can be used as an alternative to TI's official software for sending/receiving files to/from the Nspire.
-- [Cemetech](https://www.cemetech.net/) - ◒ 🎨 🌈 🎈  
+- [Cemetech](https://www.cemetech.net/) - 🎹 🎨 🌈 🎈  
   Cemetech hosts a program archive and forum pertaining to calculators of all varieties.
-- [ticalc](https://www.ticalc.org/) - ◒ 🎨 🌈 🎈  
+- [ticalc](https://www.ticalc.org/) - 🎹 🎨 🌈 🎈  
   ticalc is the go-to site to download calculator programs or upload your own.
-- [TI-Planet](https://tiplanet.org/forum/portal.php) - ◒ 🎨 🌈 🎈  
+- [TI-Planet](https://tiplanet.org/forum/portal.php) - 🎹 🎨 🌈 🎈  
   TI-Planet hosts a program archive and forum with many online tools and a large international userbase.
 
 ### ...learn TI-BASIC
 
-- [TI-Basic Starter Kit](http://tibasicdev.wikidot.com/starter-kit) - ◒ 🎨 🌈 🎈  
+- [TI-Basic Starter Kit](http://tibasicdev.wikidot.com/starter-kit) - 🎹 🎨 🌈 🎈  
   TI-Basic Developer's Starter Kit is a fantastic community-developed guide through the fundamentals of TI-BASIC, with culminating sample programs to test your understanding.
 - [TI-BASIC Programming Guide](https://education.ti.com/-/media/377A0772C3B04D83B83D2A4E51029D08) - 🌈  
   TI also provides an extensive and pedagogically-rich TI-BASIC tutorial.
-- [Code Fragments and Useful Routines](https://www.cemetech.net/forum/viewtopic.php?t=1642) - ◒ 🎨 🌈  
+- [Code Fragments and Useful Routines](https://www.cemetech.net/forum/viewtopic.php?t=1642) - 🎹 🎨 🌈  
   This community collection of optimized idioms and routines is essential for writing concise and effective TI-BASIC code.
 - [84+CE Catalog](https://education.ti.com/html/webhelp/EG_TI84PlusCE/EN/Subsystems/e-guide_ref84plus_en/content/m_appxa/aa_appxalpha.HTML) & [83PCE Catalog](https://education.ti.com/html/webhelp/EG_TI83PremCE/FR/Subsystems/e-guide_83prem_ce_fr/content/m_appxa/aa_appxalpha.HTML) - 🌈  
   TI provides documentation for every token on the calculator's built-in catalog, which you can also view online.
 
 ### ...learn assembly for my calculator
 
-- [Learn TI-83+ Assembly in 28 Days](https://taricorp.gitlab.io/83pa28d/index.html) (modernized version) &bull; Original version: [on ticalc.org](https://www.ticalc.org/archives/files/fileinfo/268/26877.html), and [web-hosted](https://tutorials.eeems.ca/ASMin28Days/welcome.html). - ◒  
+- [Learn TI-83+ Assembly in 28 Days](https://taricorp.gitlab.io/83pa28d/index.html) (modernized version) &bull; Original version: [on ticalc.org](https://www.ticalc.org/archives/files/fileinfo/268/26877.html), and [web-hosted](https://tutorials.eeems.ca/ASMin28Days/welcome.html). - 🎹  
   Assembly in 28 Days is the go-to tutorial for learning Z80 ASM; if you want to learn eZ80 as well, this guide is an essential starting point. <sup><sub>There is some work being done to create a replacement specifically for the eZ80 (i.e. the CE and variants) at https://ezce.github.io/ez80-docs/ but this is a work in progress.</sub></sub>
-- [Z80 Opcode Table](https://clrhome.org/table/) (◒) or [eZ80 Opcode Table](https://ez80.abeck.pw/) (🌈)  
+- [Z80 Opcode Table](https://clrhome.org/table/) (🎹) or [eZ80 Opcode Table](https://ez80.abeck.pw/) (🌈)  
   The opcode tables are great for learning ASM and reading hex code from others.
-- [Z80 User Manual](https://www.zilog.com/docs/z80/um0080.pdf) (◒) or [eZ80 User Manual](https://www.zilog.com/docs/um0077.pdf) (🌈)  
+- [Z80 User Manual](https://www.zilog.com/docs/z80/um0080.pdf) (🎹) or [eZ80 User Manual](https://www.zilog.com/docs/um0077.pdf) (🌈)  
   Zilog, the makers of the (e)Z80, provide official documentation for their chips and ASM instructions.
-- [TI-83+ Developer's SDK](https://education.ti.com/en/guidebook/details/en/830D08FF31804AEAA2F03B8F5E89AD14/83psdk) ([mirror](https://github.com/TI-Toolkit/awesome-ti-docs/tree/docs/sdk)) - ◒  
+- [TI-83+ Developer's SDK](https://education.ti.com/en/guidebook/details/en/830D08FF31804AEAA2F03B8F5E89AD14/83psdk) ([mirror](https://github.com/TI-Toolkit/awesome-ti-docs/tree/docs/sdk)) - 🎹  
   Official TI-83+ assembly documentation by TI. Many things apply to other calculators as well.
-- [WikiTI](https://wikiti.brandonw.net/index.php?title=Calculator_Documentation) - ◒ 🎨 🌈  
+- [WikiTI](https://wikiti.brandonw.net/index.php?title=Calculator_Documentation) - 🎹 🎨 🌈  
   WikiTI hosts community-sourced documentation on TI-OS and how to interface with it in assembly.
 
 ### ...write programs in C for my calculator
@@ -93,22 +93,22 @@ A collection of awesome calculator documentation resources and tools from all ov
 
 ### ...write and run programs on my computer
 
-- [Wabbitemu](https://github.com/sputt/wabbitemu) (◒), [jsTIfied](https://www.cemetech.net/projects/jstified/) (◒ 🎨), or [CEmu](https://ce-programming.github.io/CEmu/) (🌈)  
+- [Wabbitemu](https://github.com/sputt/wabbitemu) (🎹), [jsTIfied](https://www.cemetech.net/projects/jstified/) (🎹 🎨), or [CEmu](https://ce-programming.github.io/CEmu/) (🌈)  
   These emulators for the 83+ series of calculators allow you to run programs on your computer using a copy of your calculator's ROM.
 - [Firebird](https://github.com/nspire-emus/firebird) - 🎈  
   Nspire owners can find an emulator for their calculators in Firebird.
-- [SourceCoder 3](https://www.cemetech.net/sc/) - ◒ 🎨 🌈  
+- [SourceCoder 3](https://www.cemetech.net/sc/) - 🎹 🎨 🌈  
   SourceCoder is an online IDE for TI-BASIC, ASM, and C/C++.
 - [Project Builder](https://tiplanet.org/pb/) - 🌈  
   TI Planet's Project Builder is an online IDE for TI-BASIC, C/C++, and Python.
-- [TokenIDE](https://www.cemetech.net/downloads/files/515/x515) - ◒ 🎨 🌈  
+- [TokenIDE](https://www.cemetech.net/downloads/files/515/x515) - 🎹 🎨 🌈  
   If you'd like to go offline, TokenIDE is an IDE for TI-BASIC that supports libraries like DCS and xLibC.
 
 ### ...learn more about my calculator's hardware
 
-- [WikiTI](https://wikiti.brandonw.net/index.php?title=Calculator_Documentation) - ◒ 🎨 🌈  
+- [WikiTI](https://wikiti.brandonw.net/index.php?title=Calculator_Documentation) - 🎹 🎨 🌈  
   WikiTI hosts community-sourced hardware documentation for the 83+ series of calculators.
-- [Hardware Revisions](https://docs.google.com/spreadsheets/d/1N_2tBusqjVzefKb4impi-VwdM-RgOSIMmXBemJymxA0/edit#gid=0) - ◒ 🎨 🌈 🎈  
+- [Hardware Revisions](https://docs.google.com/spreadsheets/d/1N_2tBusqjVzefKb4impi-VwdM-RgOSIMmXBemJymxA0/edit#gid=0) - 🎹 🎨 🌈 🎈  
   This spreadsheet details every known version of hardware found in TI calculators, including prototype revisions.
 
 ## All Resources
@@ -119,9 +119,9 @@ A collection of awesome calculator documentation resources and tools from all ov
   ASM documentation, tutorials, and examples assembled by the CE toolchain team.
 - [CE Versions](https://wiki.tiplanet.org/Versions_CE/en) - 🌈  
   Boot and OS versions for the TI-84+CE(-T) and TI-83PCE.
-- [DCS Developer's SDK](https://dcs.cemetech.net/index.php?title=Developers%27_SDK) - ◒ 🎨  
+- [DCS Developer's SDK](https://dcs.cemetech.net/index.php?title=Developers%27_SDK) - 🎹 🎨  
   Documentation for Doors CS related assembly routines and formatting.
-- [Direct USB](https://brandonw.net/calcstuff/DirectUSB.txt) - ◒  
+- [Direct USB](https://brandonw.net/calcstuff/DirectUSB.txt) - 🎹  
   Partial analysis of the USB protocol on the TI-84+.
 - [eZ80 Docs](https://ezce.github.io/ez80-docs/) - 🌈  
   General documentation for assembly on the TI-84+CE (WIP).
@@ -129,60 +129,60 @@ A collection of awesome calculator documentation resources and tools from all ov
   Table of every eZ80 opcode.
 - [eZ80 User Manual](https://www.zilog.com/docs/um0077.pdf) - 🌈  
   Official Zilog documentation of the eZ80 CPU.
-- [Floating Point Hacks](https://www.cemetech.net/forum/viewtopic.php?p=274411) - ◒ 🎨 🌈  
+- [Floating Point Hacks](https://www.cemetech.net/forum/viewtopic.php?p=274411) - 🎹 🎨 🌈  
   Trick to get real variables to point to places they shouldn't. 
-- [Learn TI-83+ Assembly in 28 Days](https://taricorp.gitlab.io/83pa28d/index.html) (modernized version) &bull; Original version: [on ticalc.org](https://www.ticalc.org/archives/files/fileinfo/268/26877.html), and [web-hosted](https://tutorials.eeems.ca/ASMin28Days/welcome.html). - ◒  
+- [Learn TI-83+ Assembly in 28 Days](https://taricorp.gitlab.io/83pa28d/index.html) (modernized version) &bull; Original version: [on ticalc.org](https://www.ticalc.org/archives/files/fileinfo/268/26877.html), and [web-hosted](https://tutorials.eeems.ca/ASMin28Days/welcome.html). - 🎹  
   Guide to learning assembly on the TI-83+; a useful starting point for writing assembly for other models.
-- [Link Guide](http://merthsoft.com/linkguide/ti83+/) ([mirror](https://debrouxl.github.io/tilp-linkguide/)) - ◒  
+- [Link Guide](http://merthsoft.com/linkguide/ti83+/) ([mirror](https://debrouxl.github.io/tilp-linkguide/)) - 🎹  
   Link protocol documentation for TI-83+/84+ calculators. Also contains useful documentation for variable formats.
-- [TI-83+ Developer's SDK](https://education.ti.com/en/guidebook/details/en/830D08FF31804AEAA2F03B8F5E89AD14/83psdk) ([mirror](https://github.com/TI-Toolkit/awesome-ti-docs/tree/docs/sdk)) - ◒  
+- [TI-83+ Developer's SDK](https://education.ti.com/en/guidebook/details/en/830D08FF31804AEAA2F03B8F5E89AD14/83psdk) ([mirror](https://github.com/TI-Toolkit/awesome-ti-docs/tree/docs/sdk)) - 🎹  
   Official TI-83+ assembly documentation by TI. Many things apply to other calculators as well.
-- [tilibs](https://github.com/debrouxl/tilibs) - ◒ 🎨 🌈 🎈  
+- [tilibs](https://github.com/debrouxl/tilibs) - 🎹 🎨 🌈 🎈  
   Libraries utilized by TiLP and other software to transfer and convert files between calculators.
-- [WikiTI](https://wikiti.brandonw.net/index.php?title=Calculator_Documentation) - ◒ 🎨 🌈  
+- [WikiTI](https://wikiti.brandonw.net/index.php?title=Calculator_Documentation) - 🎹 🎨 🌈  
   Contains most of the documented system calls, along with other useful information pertaining to calculator software/hardware.
-- [Z80 IDE](https://clrhome.org/asm/) - ◒  
+- [Z80 IDE](https://clrhome.org/asm/) - 🎹  
   Online IDE for Z80 ASM.
-- [Z80 Opcode Table](https://clrhome.org/table/) - ◒  
+- [Z80 Opcode Table](https://clrhome.org/table/) - 🎹  
   Table of every Z80 opcode.
-- [Z80 Optimized Routines](https://github.com/Zeda/Z80-Optimized-Routines) - ◒  
+- [Z80 Optimized Routines](https://github.com/Zeda/Z80-Optimized-Routines) - 🎹  
   Expertly-crafted optimized routines for common algorithms, graphics, and mathematical operations (among other things).
-- [Z80 User Manual](https://www.zilog.com/docs/z80/um0080.pdf) - ◒  
+- [Z80 User Manual](https://www.zilog.com/docs/z80/um0080.pdf) - 🎹  
   Official Zilog documentation of the Z80 CPU.
 
 ### TI-BASIC
 
 - [84+CE Catalog (English)](https://education.ti.com/html/webhelp/EG_TI84PlusCE/EN/Subsystems/e-guide_ref84plus_en/content/m_appxa/aa_appxalpha.HTML) / [83PCE Catalog (French)](https://education.ti.com/html/webhelp/EG_TI83PremCE/FR/Subsystems/e-guide_83prem_ce_fr/content/m_appxa/aa_appxalpha.HTML) - 🌈  
   A copy of the Catalog for the TI-84+CE/TI-83PCE.
-- Assembly Hex Codes for the [83+/84+](http://tibasicdev.wikidot.com/hexcodes) (◒), [84+CSE](http://tibasicdev.wikidot.com/84cse:hexcodes) (🎨), and [84+CE](http://tibasicdev.wikidot.com/84ce:hexcodes) (🌈)  
+- Assembly Hex Codes for the [83+/84+](http://tibasicdev.wikidot.com/hexcodes) (🎹), [84+CSE](http://tibasicdev.wikidot.com/84cse:hexcodes) (🎨), and [84+CE](http://tibasicdev.wikidot.com/84ce:hexcodes) (🌈)  
   Short assembly snippets that can be called from TI-BASIC using the `AsmPrgm` commands.
-- [binomcdf( Shenanigans](https://www.cemetech.net/forum/viewtopic.php?t=17286) - ◒ 🎨 🌈  
+- [binomcdf( Shenanigans](https://www.cemetech.net/forum/viewtopic.php?t=17286) - 🎹 🎨 🌈  
   Exploration of a bug in the `binomcdf(` implementation between OS 1.03 and 5.6.1 that produces corrupted floats.
 - [Celtic CE Documentation](https://roccoloxprograms.github.io/CelticCE) - 🌈  
   Documentation of the third-party TI-BASIC library Celtic CE.
-- [Code Fragments and Useful Routines](https://www.cemetech.net/forum/viewtopic.php?t=1642) - ◒ 🎨 🌈  
+- [Code Fragments and Useful Routines](https://www.cemetech.net/forum/viewtopic.php?t=1642) - 🎹 🎨 🌈  
   Various useful routines for TI-BASIC programs.
-- [DCS Developer's SDK](https://dcs.cemetech.net/index.php?title=Developers%27_SDK) - ◒ 🎨  
+- [DCS Developer's SDK](https://dcs.cemetech.net/index.php?title=Developers%27_SDK) - 🎹 🎨  
   Documentation of third-party TI-BASIC libraries included in Doors CS/CSE.
-- [Error Messages](https://education.ti.com/html/webhelp/EG_TI84PlusCE/UK/Subsystems/eg_ti84plusce_ref/content/m_errors/em_errormessages.HTML) - ◒ 🎨 🌈  
+- [Error Messages](https://education.ti.com/html/webhelp/EG_TI84PlusCE/UK/Subsystems/eg_ti84plusce_ref/content/m_errors/em_errormessages.HTML) - 🎹 🎨 🌈  
   TI's reference for the possible error types and messages on the CE.
-- [For( Documentation](https://github.com/TI-Toolkit/awesome-ti-docs/blob/docs/for_documentation.md) - ◒ 🎨 🌈  
+- [For( Documentation](https://github.com/TI-Toolkit/awesome-ti-docs/blob/docs/for_documentation.md) - 🎹 🎨 🌈  
   Documentation of strange behavior of the `For(` command.
-- [A Guide to Code Golf in TI-BASIC](https://gist.github.com/tkwa/f0c82e04e159d83e2321a736c95630f3) - ◒ 🎨 🌈  
+- [A Guide to Code Golf in TI-BASIC](https://gist.github.com/tkwa/f0c82e04e159d83e2321a736c95630f3) - 🎹 🎨 🌈  
   Replete guide with tips and tricks for TI-BASIC code golfing.
 - [TEXTLIB](https://www.cemetech.net/downloads/files/1340/x1340) - 🎨 🌈  
   TI-BASIC library to enhance homescreen and graphscreen drawing capabilities.
-- [TI-Basic Developer](http://tibasicdev.wikidot.com/) - ◒ 🎨 🌈 🎈  
+- [TI-Basic Developer](http://tibasicdev.wikidot.com/) - 🎹 🎨 🌈 🎈  
   Documentation and tutorials for TI-BASIC programming.
 - [TI-Basic Programming Guide for the TI-84+CE](https://education.ti.com/html/eguides/graphing/84PlusCEPy/EN/content/eg_84prgm/m_splashpage/ti-progguide_ce.HTML) - 🌈  
   TI's own guide and command reference for programming in TI-BASIC. The eGuide also includes reference for other CE features and apps.
-- [TI-BASIC Useful Routines](https://learn.cemetech.net/index.php?title=TI-BASIC:Useful_Routines) - ◒ 🎨 🌈  
+- [TI-BASIC Useful Routines](https://learn.cemetech.net/index.php?title=TI-BASIC:Useful_Routines) - 🎹 🎨 🌈  
   Useful routines for TI-BASIC programs.
-- [tiopt](https://www.club.cc.cmu.edu/~ajo/ti/tiopt.html) - ◒ 🎨 🌈  
+- [tiopt](https://www.club.cc.cmu.edu/~ajo/ti/tiopt.html) - 🎹 🎨 🌈  
   Tool to perform simple optimizations of TI-BASIC programs.
 - [QR Code Generator](https://tiplanet.org/scripts/qrcode/) - 🌈  
   QR code generator for use with TI-BASIC. Requires the accompanying [rendering program](https://tiplanet.org/forum/archives_voir.php?id=324393).
-- [zText](https://tiplanet.org/scripts/zText/) - ◒ 🎨 🌈  
+- [zText](https://tiplanet.org/scripts/zText/) - 🎹 🎨 🌈  
   Simple program generator for displaying text on the graphscreen.
 
 ### C/C++
@@ -194,13 +194,13 @@ A collection of awesome calculator documentation resources and tools from all ov
 
 ### Hardware
 
-- [Hardware Revisions](https://docs.google.com/spreadsheets/d/1N_2tBusqjVzefKb4impi-VwdM-RgOSIMmXBemJymxA0/edit#gid=0) - ◒ 🎨 🌈 🎈  
+- [Hardware Revisions](https://docs.google.com/spreadsheets/d/1N_2tBusqjVzefKb4impi-VwdM-RgOSIMmXBemJymxA0/edit#gid=0) - 🎹 🎨 🌈 🎈  
   Documented hardware revisions, motherboards, and codenames for calculators and accessories.
-- [Packaging Codes](https://docs.google.com/spreadsheets/d/1GumHduVgHWHIiJPKUKDZEtlZmMOOxRv2RqHLKyzRKos/edit#gid=0) - ◒ 🎨 🌈 🎈  
+- [Packaging Codes](https://docs.google.com/spreadsheets/d/1GumHduVgHWHIiJPKUKDZEtlZmMOOxRv2RqHLKyzRKos/edit#gid=0) - 🎹 🎨 🌈 🎈  
   Documented serial numbers and packaging codes.
-- [Silver Link RE](https://www.cemetech.net/forum/viewtopic.php?p=302980) - ◒ 🎨 🌈  
+- [Silver Link RE](https://www.cemetech.net/forum/viewtopic.php?p=302980) - 🎹 🎨 🌈  
   Documentation and schematics for the TI USB Graph Silver Link cable.
-- [WikiTI](https://wikiti.brandonw.net/index.php?title=Calculator_Documentation) - ◒ 🎨 🌈  
+- [WikiTI](https://wikiti.brandonw.net/index.php?title=Calculator_Documentation) - 🎹 🎨 🌈  
   Contains hardware documentation for some TI (e)Z80 calculators.
 
 ### Emulators
@@ -209,22 +209,22 @@ A collection of awesome calculator documentation resources and tools from all ov
   TI-84+CE emulator for Linux, macOS, and Windows.
 - [Firebird](https://github.com/nspire-emus/firebird) - 🎈  
   TI-Nspire emulator for Android, iOS, Linux, macOS, and Windows.
-- [jsTIfied](https://www.cemetech.net/projects/jstified/) - ◒ 🎨  
+- [jsTIfied](https://www.cemetech.net/projects/jstified/) - 🎹 🎨  
   Online calculator emulator for Z80 TI-83+/84+ calculators.
-- [TilEm](http://lpg.ticalc.org/prj_tilem/) - ◒  
+- [TilEm](http://lpg.ticalc.org/prj_tilem/) - 🎹  
   TI Z80 emulator and debugger for Linux, macOS, Windows, and other platforms that support GTK+.
-- [Wabbitemu](https://github.com/sputt/wabbitemu) - ◒  
+- [Wabbitemu](https://github.com/sputt/wabbitemu) - 🎹  
   TI Z80 emulator for Android, Linux, macOS, and Windows.
 
 ### Downloads
 
-- [Cemetech](https://www.cemetech.net/) - ◒ 🎨 🌈 🎈  
+- [Cemetech](https://www.cemetech.net/) - 🎹 🎨 🌈 🎈  
   Archive and forum site hosting discussion pertaining to calculators and other projects.
-- [TI-Basic Developer](http://tibasicdev.wikidot.com/home) - ◒ 🎨 🌈 🎈  
+- [TI-Basic Developer](http://tibasicdev.wikidot.com/home) - 🎹 🎨 🌈 🎈  
   Archive and forum site with a focus on TI-BASIC.
-- [ticalc](https://www.ticalc.org/) - ◒ 🎨 🌈 🎈  
+- [ticalc](https://www.ticalc.org/) - 🎹 🎨 🌈 🎈  
   Replete archive of calculator programs and other files.
-- [TI-Planet](https://tiplanet.org/forum/portal.php) - ◒ 🎨 🌈 🎈  
+- [TI-Planet](https://tiplanet.org/forum/portal.php) - 🎹 🎨 🌈 🎈  
   Archive and forum site tailored to TI calculators with a large international community.
 
 ### Tools
@@ -233,13 +233,13 @@ A collection of awesome calculator documentation resources and tools from all ov
   Color picker which can use 1555 or 565 color mode, which can be useful for C/ASM and hybrid TI-BASIC on color calculators.
 - [arTIfiCE](https://yvantt.github.io/arTIfiCE/) - 🌈  
   "Jailbreak" for the TI-84+CE/83PCE calculators necessary for running ASM programs on OS versions 5.5 and above.
-- [FactoRoms](https://tiplanet.org/forum/factoroms.php) - ◒ 🎨 🌈 🎈  
+- [FactoRoms](https://tiplanet.org/forum/factoroms.php) - 🎹 🎨 🌈 🎈  
   Online console ROM to calculator file conversion tool (requires TI Planet log-in).
-- [fasmg manual](https://flatassembler.net/docs.php?article=fasmg_manual) - ◒ 🎨 🌈  
+- [fasmg manual](https://flatassembler.net/docs.php?article=fasmg_manual) - 🎹 🎨 🌈  
   Documentation and basic examples of flat assembler g language.
 - [img2calc](https://tiplanet.org/forum/img2calc.php) - 🌈 🎈  
   Image converter for a number of calculator image file types.
-- [mViewer GX Creator](https://tiplanet.org/gx) - ◒ 🎨 🌈 🎈  
+- [mViewer GX Creator](https://tiplanet.org/gx) - 🎹 🎨 🌈 🎈  
   Online PDF/Image to calculator file conversion tool (requires TI Planet log-in).
 - [nCreator](https://tiplanet.org/forum/edittns.php) - 🎈  
   Online rich text (Nspire Notes app) creation tool (requires TI Planet log-in).
@@ -247,22 +247,22 @@ A collection of awesome calculator documentation resources and tools from all ov
   Free and open-source TI-Nspire transfer software for Linux, macOS, and Windows (no license required).
 - [Project Builder](https://tiplanet.org/pb/) - 🌈  
   Online C/C++, TI-BASIC, and Python IDE for TI-84+CE/83PCE calculators.
-- [SourceCoder 3](https://www.cemetech.net/sc/) - ◒ 🎨 🌈  
+- [SourceCoder 3](https://www.cemetech.net/sc/) - 🎹 🎨 🌈  
   Online IDE for TI-BASIC, (e)Z80 ASM, and C programs.
-- [TILP](https://github.com/debrouxl/tilp_and_gfm/) - ◒ 🎨 🌈 🎈  
+- [TILP](https://github.com/debrouxl/tilp_and_gfm/) - 🎹 🎨 🌈 🎈  
   Open-source calculator transfer software for most calculators and link cables.
-- [tivars_lib_cpp](https://github.com/adriweb/tivars_lib_cpp)/[tivars_lib_py](https://github.com/TI-Toolkit/tivars_lib_py) - ◒ 🎨 🌈  
+- [tivars_lib_cpp](https://github.com/adriweb/tivars_lib_cpp)/[tivars_lib_py](https://github.com/TI-Toolkit/tivars_lib_py) - 🎹 🎨 🌈  
   Libraries for C++/Python to read and write var files used by TI-(e)Z80 calculators.
-- [TokenIDE](https://www.cemetech.net/downloads/files/515/x515) - ◒ 🎨 🌈  
+- [TokenIDE](https://www.cemetech.net/downloads/files/515/x515) - 🎹 🎨 🌈  
   Offline IDE for TI-BASIC with DCS and xLibC support.
 - [xLibC Color Picker](https://roccoloxprograms.github.io/XlibcColorPicker/) - 🎨 🌈  
   Color picker which uses the xLibC palette, which can be useful for C/ASM and hybrid TI-BASIC on color calculators. You can upload a custom palette as well.
 
 ### Other
 
-- [AXE Commands](https://axe.eeems.ca/Commands.html) - ◒  
+- [AXE Commands](https://axe.eeems.ca/Commands.html) - 🎹  
   Table of commands for the TI-83+/84+ programming language AXE, created by Kevin Horowitz.
-- [AXE Documentation](https://axe.eeems.ca/Documentation.pdf) - ◒  
+- [AXE Documentation](https://axe.eeems.ca/Documentation.pdf) - 🎹  
   General documentation for AXE in PDF form.
 - [ICE Documentation](http://petertillema.github.io/ICE/) - 🌈  
   Documentation for the TI-84+CE programming language ICE, created by Peter Tillema. Note: ICE is no longer in active development.


### PR DESCRIPTION
Example of `◒` being very hard to read sometime:

<img width="265" height="211" alt="20250711-100238-999 awesome-ti-docs" src="https://github.com/user-attachments/assets/114c7222-3f4e-4e47-beda-0e00108466b5" />

So with 🎹 instead it may work better.